### PR TITLE
Changed the router typehint to use the interface

### DIFF
--- a/Form/Extension/VideoUploaderExtension.php
+++ b/Form/Extension/VideoUploaderExtension.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\UrlGenerator\UrlGeneratorInterface;
 
 /**
  * Extends the {@link http://api.symfony.com/master/Symfony/Component/Form/Extension/Core/Type/FileType.html FileType}
@@ -42,10 +42,10 @@ class VideoUploaderExtension extends AbstractTypeExtension
     /**
      * Constructor.
      *
-     * @param \Symfony\Component\Routing\Router $router The router
+     * @param UrlGeneratorInterface $router The router
      * @param array $defaultOptions Default display options for widget objects
      */
-    public function __construct(Router $router, array $defaultOptions)
+    public function __construct(UrlGeneratorInterface $router, array $defaultOptions)
     {
         $this->router = $router;
         $this->defaultOptions = $defaultOptions;


### PR DESCRIPTION
typehinting the router implementation is a bad idea as it prevents using this bundle with bundles decorating the router. The interface should always be used in typehints.

and this class only needs the url generation part of the router, so it makes sense to typehint only the UrlGeneratorInterface rather than the full RouterInterface (which extends both UrlGeneratorInterface and UrlMatcherInterface)
