### PR TITLE
Fixed the minimum requirement of the library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/http-kernel": "~2.2",
         "symfony/options-resolver": "~2.2",
         "symfony/routing": "~2.2",
-        "xabbuh/panda-client": "~1.0"
+        "xabbuh/panda-client": "~1.1"
     },
     "require-dev": {
         "symfony/browser-kit": "~2.2",


### PR DESCRIPTION
Pandabundle relies on methods added in the version 1.1 of the client
