### PR TITLE
Remove usage of deprecated APIs in symfony 2.7+

### DIFF
--- a/DependencyInjection/XabbuhPandaExtension.php
+++ b/DependencyInjection/XabbuhPandaExtension.php
@@ -58,6 +58,16 @@ class XabbuhPandaExtension extends Extension
         $loader->load('transformers.xml');
         $loader->load('video_uploader_extension.xml');
 
+        // Add the tag for the form type extension without using deprecated APIs
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $extendedType = 'Symfony\Component\Form\Extension\Core\Type\FileType';
+        } else {
+            $extendedType = 'file';
+        }
+
+        $container->getDefinition('xabbuh_panda.video_uploader_extension')
+            ->addTag('form.type_extension', array('alias' => $extendedType));
+
         $this->loadAccounts($config['accounts'], $container);
         $this->loadClouds($config['clouds'], $container);
         $this->registerSerializerFactory($container);

--- a/Form/Extension/VideoUploaderExtension.php
+++ b/Form/Extension/VideoUploaderExtension.php
@@ -56,7 +56,12 @@ class VideoUploaderExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return "file";
+        // BC with Symfony < 2.8
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            return 'file';
+        }
+
+        return 'Symfony\Component\Form\Extension\Core\Type\FileType';
     }
 
     /**

--- a/Form/Extension/VideoUploaderExtension.php
+++ b/Form/Extension/VideoUploaderExtension.php
@@ -14,6 +14,7 @@ namespace Xabbuh\PandaBundle\Form\Extension;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -63,19 +64,37 @@ class VideoUploaderExtension extends AbstractTypeExtension
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setOptional(
-            array(
-                "panda_widget",
-                "panda_widget_version",
-                "cloud",
-                "multiple_files",
-                "cancel_button",
-                "progress_bar"
-            )
+        // BC for symfony 2.6 and older which don't have the forward-compatibility layer
+        if (!$resolver instanceof OptionsResolver) {
+            throw new \InvalidArgumentException(sprintf('Custom resolver "%s" must extend "Symfony\Component\OptionsResolver\OptionsResolver".', get_class($resolver)));
+        }
+
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $optionalOptions = array(
+            "panda_widget",
+            "panda_widget_version",
+            "cloud",
+            "multiple_files",
+            "cancel_button",
+            "progress_bar",
         );
-        $resolver->setAllowedValues(
-            array("panda_widget_version" => array(1, 2))
-        );
+
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setDefined($optionalOptions);
+            $resolver->setAllowedValues('panda_widget_version', array(1, 2));
+        } else {
+            $resolver->setOptional($optionalOptions);
+            $resolver->setAllowedValues(
+                array("panda_widget_version" => array(1, 2))
+            );
+        }
     }
 
     /**

--- a/Resources/config/video_uploader_extension.xml
+++ b/Resources/config/video_uploader_extension.xml
@@ -14,7 +14,7 @@
                 <argument key="cancel_button">%xabbuh_panda.video_uploader.cancel_button%</argument>
                 <argument key="progress_bar">%xabbuh_panda.video_uploader.progress_bar%</argument>
             </argument>
-            <tag name="form.type_extension" alias="file"/>
+            <!-- The tag is added in the extension to avoid deprecation warnings in 2.8+ -->
         </service>
     </services>
 </container>

--- a/Tests/Form/Extension/VideoUploaderExtensionTest.php
+++ b/Tests/Form/Extension/VideoUploaderExtensionTest.php
@@ -11,168 +11,128 @@
 
 namespace Xabbuh\PandaBundle\Tests\Form\Extension;
 
-use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\FormIntegrationTestCase;
 use Xabbuh\PandaBundle\Form\Extension\VideoUploaderExtension;
 
 /**
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
  */
-class VideoUploaderExtensionTest extends \PHPUnit_Framework_TestCase
+class VideoUploaderExtensionTest extends FormIntegrationTestCase
 {
-    /**
-     * @var VideoUploaderExtension
-     */
-    private $extension;
-
     /**
      * @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface
      */
     private $urlGenerator;
 
-    /**
-     * @var \Symfony\Component\Form\FormView
-     */
-    private $formView;
-
-    /**
-     * @var \Symfony\Component\Form\FormInterface
-     */
-    private $form;
-
     protected function setUp()
     {
-        $this->urlGenerator = $this->createUrlGeneratorMock();
-        $this->formView = $this->createFormView();
-        $this->form = $this->createFormInterfaceMock();
+        $this->urlGenerator = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+
+        parent::setUp();
+    }
+
+    protected function getExtensions()
+    {
         $defaultOptions = array(
             'multiple_files' => false,
             'cancel_button' => false,
             'progress_bar' => false,
         );
-        $this->extension = new VideoUploaderExtension($this->urlGenerator, $defaultOptions);
+        $extension = new VideoUploaderExtension($this->urlGenerator, $defaultOptions);
+
+        return array(
+            new PreloadedExtension(array(), array($extension->getExtendedType() => array($extension))),
+        );
     }
 
     public function testWidgetIsDisabledByDefault()
     {
-        $this->buildView(array(), false);
+        $formView = $this->buildView(array(), false);
 
-        $this->assertFalse($this->formView->vars['panda_uploader']);
+        $this->assertFalse($formView->vars['panda_uploader']);
     }
 
     public function testEnableWidget()
     {
-        $this->buildView();
+        $formView = $this->buildView();
 
-        $this->assertTrue($this->formView->vars['panda_uploader']);
+        $this->assertTrue($formView->vars['panda_uploader']);
     }
 
     public function testEnableWidgetWithNonBoolOptionValue()
     {
-        $this->buildView(array('panda_widget' => 'yes'));
+        $formView = $this->buildView(array('panda_widget' => 'yes'));
 
-        $this->assertTrue($this->formView->vars['panda_uploader']);
-    }
-
-    public function testIdHasToBeSetToEnableTheWidget()
-    {
-        $this->buildView(array(), true, null);
-
-        $this->assertFalse($this->formView->vars['panda_uploader']);
+        $this->assertTrue($formView->vars['panda_uploader']);
     }
 
     public function testDefaultWidgetVersion()
     {
-        $this->buildView(array());
+        $formView = $this->buildView(array());
 
-        $this->assertEquals('v2', $this->formView->vars['attr']['panda-uploader']);
+        $this->assertEquals('v2', $formView->vars['attr']['panda-uploader']);
     }
 
     public function testWidgetVersionCanBeChanged()
     {
-        $this->buildView(array('panda_widget_version' => 1), true);
+        $formView = $this->buildView(array('panda_widget_version' => 1), true);
 
-        $this->assertEquals('v1', $this->formView->vars['attr']['panda-uploader']);
+        $this->assertEquals('v1', $formView->vars['attr']['panda-uploader']);
     }
 
     public function testDefaultOptions()
     {
-        $this->buildView();
+        $formView = $this->buildView();
 
-        $this->assertEquals('false', $this->formView->vars['attr']['multiple_files']);
-        $this->assertFalse($this->formView->vars['cancel_button']);
-        $this->assertFalse($this->formView->vars['progress_bar']);
+        $this->assertEquals('false', $formView->vars['attr']['multiple_files']);
+        $this->assertFalse($formView->vars['cancel_button']);
+        $this->assertFalse($formView->vars['progress_bar']);
     }
 
     public function testMultipleFilesUploadsCanBeEnabled()
     {
-        $this->buildView(array('multiple_files' => true));
+        $formView = $this->buildView(array('multiple_files' => true));
 
-        $this->assertEquals('true', $this->formView->vars['attr']['multiple_files']);
+        $this->assertEquals('true', $formView->vars['attr']['multiple_files']);
     }
 
     public function testCancelButtonCanBeEnabled()
     {
-        $this->buildView(array('cancel_button' => true));
+        $formView = $this->buildView(array('cancel_button' => true));
 
-        $this->assertTrue($this->formView->vars['cancel_button']);
+        $this->assertTrue($formView->vars['cancel_button']);
     }
 
     public function testProgressBarCanBeEnabled()
     {
-        $this->buildView(array('progress_bar' => true));
+        $formView = $this->buildView(array('progress_bar' => true));
 
-        $this->assertTrue($this->formView->vars['progress_bar']);
+        $this->assertTrue($formView->vars['progress_bar']);
     }
 
     public function testBrowseButtonId()
     {
-        $this->buildView(array(), true, 'bar');
+        $formView = $this->buildView(array(), true, 'bar');
 
-        $this->assertEquals('browse_button_bar', $this->formView->vars['attr']['browse-button-id']);
-        $this->assertEquals('browse_button_bar', $this->formView->vars['browse_button_id']);
+        $this->assertEquals('browse_button_bar', $formView->vars['attr']['browse-button-id']);
+        $this->assertEquals('browse_button_bar', $formView->vars['browse_button_id']);
     }
 
     public function testCancelButtonId()
     {
-        $this->buildView(array('cancel_button' => true), true, 'baz');
+        $formView = $this->buildView(array('cancel_button' => true), true, 'baz');
 
-        $this->assertEquals('cancel_button_baz', $this->formView->vars['attr']['cancel-button-id']);
-        $this->assertEquals('cancel_button_baz', $this->formView->vars['cancel_button_id']);
+        $this->assertEquals('cancel_button_baz', $formView->vars['attr']['cancel-button-id']);
+        $this->assertEquals('cancel_button_baz', $formView->vars['cancel_button_id']);
     }
 
     public function testProgressBarId()
     {
-        $this->buildView(array('progress_bar' => true), true, 'foobar');
+        $formView = $this->buildView(array('progress_bar' => true), true, 'foobar');
 
-        $this->assertEquals('progress_bar_foobar', $this->formView->vars['attr']['progress-bar-id']);
-        $this->assertEquals('progress_bar_foobar', $this->formView->vars['progress_bar_id']);
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\Routing\Generator\UrlGeneratorInterface
-     */
-    private function createUrlGeneratorMock()
-    {
-        return $this
-            ->getMockBuilder('\Symfony\Component\Routing\Generator\UrlGeneratorInterface')
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
-
-    /**
-     * @return \Symfony\Component\Form\FormView
-     */
-    private function createFormView()
-    {
-        return new FormView();
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\Form\FormInterface
-     */
-    private function createFormInterfaceMock()
-    {
-        return $this->getMock('\Symfony\Component\Form\FormInterface');
+        $this->assertEquals('progress_bar_foobar', $formView->vars['attr']['progress-bar-id']);
+        $this->assertEquals('progress_bar_foobar', $formView->vars['progress_bar_id']);
     }
 
     private function buildView(array $options = array(), $enable = true, $id = 'foo')
@@ -181,12 +141,10 @@ class VideoUploaderExtensionTest extends \PHPUnit_Framework_TestCase
             $options['panda_widget'] = true;
         }
 
-        if (isset($options['panda_widget']) && $options['panda_widget']) {
-            $this->formView->vars['id'] = $id;
-        }
-
         $options['cloud'] = 'the-cloud';
 
-        $this->extension->buildView($this->formView, $this->form, $options);
+        $form = $this->factory->createNamed($id, 'file', null, $options);
+
+        return $form->createView();
     }
 }

--- a/Tests/Form/Extension/VideoUploaderExtensionTest.php
+++ b/Tests/Form/Extension/VideoUploaderExtensionTest.php
@@ -143,7 +143,13 @@ class VideoUploaderExtensionTest extends FormIntegrationTestCase
 
         $options['cloud'] = 'the-cloud';
 
-        $form = $this->factory->createNamed($id, 'file', null, $options);
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $type = 'Symfony\Component\Form\Extension\Core\Type\FileType';
+        } else {
+            $type = 'file';
+        }
+
+        $form = $this->factory->createNamed($id, $type, null, $options);
 
         return $form->createView();
     }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "symfony/browser-kit": "~2.2",
         "symfony/finder": "~2.2",
         "symfony/framework-bundle": "~2.2",
+        "symfony/phpunit-bridge": "~2.7",
         "symfony/validator": "~2.3"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,13 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "doctrine/common": "~2.0",
         "symfony/config": "~2.2",
         "symfony/console": "~2.3",
         "symfony/dependency-injection": "~2.3",
         "symfony/event-dispatcher": "~2.2",
-        "symfony/form": "~2.2",
+        "symfony/form": "~2.3",
         "symfony/http-foundation": "~2.2",
-        "symfony/http-kernel": "~2.2",
+        "symfony/http-kernel": "~2.3",
         "symfony/options-resolver": "~2.2",
         "symfony/routing": "~2.2",
         "xabbuh/panda-client": "~1.1"
@@ -31,7 +30,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "~0.7",
         "symfony/browser-kit": "~2.2",
         "symfony/finder": "~2.2",
-        "symfony/framework-bundle": "~2.2",
+        "symfony/framework-bundle": "~2.3",
         "symfony/phpunit-bridge": "~2.7",
         "symfony/validator": "~2.3"
     },


### PR DESCRIPTION
I rewrote the tests of the form extension to rely on the FormIntegrationTestCase, to make the extension run inside the Form component.
Without this, the testsuite was not catching the deprecation.

this also allowed me to remove a useless test: the id variable is always set by the Symfony form type