### PR TITLE
Fix the scrutinizer coverage upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,8 @@ install:
 
 script:
   - phpunit --coverage-clover=coverage.clover
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  
+after_script:
+  # PHP 7.0 and HHVM 3.5 are not able to generate code coverage
+  # Avoid notifying that generating it failed to let other jobs upload it rather than  cancelling the Scrutinizer job
+  - if [[ "$TRAVIS_PHP_VERSION" != "7.0" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi


### PR DESCRIPTION
PHP 7 and HHVM 3.5 are not able to generate code coverage. Trying to upload it in such case will cancel the Scrutinizer analysis if it is the first job to finish.