### PR TITLE
Fix the composer install for symfony 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION="2.7.x"
     - php: 5.6
-      env: SYMFONY_VERSION="2.8.x@dev"
+      env: SYMFONY_VERSION="2.8.x@dev symfony/security-acl:2.8.*@dev"
     - php: 7.0
     - php: hhvm
   allow_failures:


### PR DESCRIPTION
We need to allow the installation of the unstable security-acl package too for 2.8 as it is not released yet