### PR TITLE
Simplify the form type extension

### DIFF
--- a/Tests/Form/Extension/VideoUploaderExtensionTest.php
+++ b/Tests/Form/Extension/VideoUploaderExtensionTest.php
@@ -135,6 +135,20 @@ class VideoUploaderExtensionTest extends FormIntegrationTestCase
         $this->assertEquals('progress_bar_foobar', $formView->vars['progress_bar_id']);
     }
 
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testExceptionForWidgetWithoutCloud()
+    {
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $type = 'Symfony\Component\Form\Extension\Core\Type\FileType';
+        } else {
+            $type = 'file';
+        }
+
+        $this->factory->create($type, null, array('panda_widget' => true));
+    }
+
     private function buildView(array $options = array(), $enable = true, $id = 'foo')
     {
         if (!isset($options['panda_widget']) && $enable) {


### PR DESCRIPTION
Default values are not handled through the options resolver, ensuring they are always available in buildView.
A validation is also added to make the cloud option required when enabling the panda widget.

This is best reviewed with [whitespace changes ignored](https://github.com/xabbuh/PandaBundle/pull/9/files?w=1) as the indentation of the buildView code changed (I used an early return when disabling the widget)