### PR TITLE
Rename some variables for better meaning

### DIFF
--- a/DependencyInjection/Compiler/ProviderPass.php
+++ b/DependencyInjection/Compiler/ProviderPass.php
@@ -32,7 +32,7 @@ class ProviderPass implements CompilerPassInterface
         if ($container->hasDefinition("xabbuh_panda.account_manager")) {
             $accountManager = $container->getDefinition("xabbuh_panda.account_manager");
             $accountProviderServices = $container->findTaggedServiceIds("xabbuh_panda.account_provider");
-            foreach ($accountProviderServices as $id => $attributes) {
+            foreach ($accountProviderServices as $id => $tags) {
                 $accountManager->addMethodCall("registerProvider", array(new Reference($id)));
             }
         }
@@ -41,7 +41,7 @@ class ProviderPass implements CompilerPassInterface
         if ($container->hasDefinition("xabbuh_panda.cloud_manager")) {
             $cloudManager = $container->getDefinition("xabbuh_panda.cloud_manager");
             $cloudProviderServices = $container->findTaggedServiceIds("xabbuh_panda.cloud_provider");
-            foreach ($cloudProviderServices as $id => $attributes) {
+            foreach ($cloudProviderServices as $id => $tags) {
                 $cloudManager->addMethodCall("registerProvider", array(new Reference($id)));
             }
         }


### PR DESCRIPTION
These values are not actually used currently, but they are an array of tags, not an array of attributes (each tag is an array of attribute).

The change is mainly educational, so that people reading the code don't think we get attributes this way (even Symfony had lots of this wrong naming in previous versions, and may still have it in some places)