### PR TITLE
Remove wrong required validation in the XSD schema for the config

### DIFF
--- a/Resources/config/schema/panda-1.0.xsd
+++ b/Resources/config/schema/panda-1.0.xsd
@@ -21,14 +21,14 @@
 
     <xsd:complexType name="account">
         <xsd:attribute name="name" type="xsd:string" use="required" />
-        <xsd:attribute name="access-key" type="xsd:string" use="required" />
-        <xsd:attribute name="secret-key" type="xsd:string" use="required" />
+        <xsd:attribute name="access-key" type="xsd:string" />
+        <xsd:attribute name="secret-key" type="xsd:string" />
         <xsd:attribute name="api-host" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="cloud">
         <xsd:attribute name="name" type="xsd:string" use="required" />
-        <xsd:attribute name="id" type="xsd:string" use="required" />
+        <xsd:attribute name="id" type="xsd:string" />
         <xsd:attribute name="account" type="xsd:string" />
     </xsd:complexType>
 


### PR DESCRIPTION
These attributes are required in the merged config, not in each of the merged files configuring the bundle. The only attribute required in all files is the key of the hash.