### PR TITLE
fix test for thrown exception message

### DIFF
--- a/Tests/Command/CancelEncodingCommandTest.php
+++ b/Tests/Command/CancelEncodingCommandTest.php
@@ -44,7 +44,7 @@ class CancelEncodingCloudCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/ChangeUrlCommandTest.php
+++ b/Tests/Command/ChangeUrlCommandTest.php
@@ -43,7 +43,7 @@ class ChangeUrlCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/CreateEncodingCommandTest.php
+++ b/Tests/Command/CreateEncodingCommandTest.php
@@ -77,7 +77,7 @@ class CreateEncodingCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/CreateProfileCommandTest.php
+++ b/Tests/Command/CreateProfileCommandTest.php
@@ -46,7 +46,7 @@ class CreateProfileCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/DeleteEncodingCommandTest.php
+++ b/Tests/Command/DeleteEncodingCommandTest.php
@@ -41,7 +41,7 @@ class DeleteEncodingCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/DeleteProfileCommandTest.php
+++ b/Tests/Command/DeleteProfileCommandTest.php
@@ -41,7 +41,7 @@ class DeleteProfileCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/DeleteVideoCommandTest.php
+++ b/Tests/Command/DeleteVideoCommandTest.php
@@ -41,7 +41,7 @@ class DeleteVideoCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/DisableEventCommandTest.php
+++ b/Tests/Command/DisableEventCommandTest.php
@@ -45,7 +45,7 @@ class DisableEventCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/EnableEventCommandTest.php
+++ b/Tests/Command/EnableEventCommandTest.php
@@ -45,7 +45,7 @@ class EnableEventCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/EncodingInfoCommandTest.php
+++ b/Tests/Command/EncodingInfoCommandTest.php
@@ -111,7 +111,7 @@ class EncodingInfoCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/ModifyCloudCommandTest.php
+++ b/Tests/Command/ModifyCloudCommandTest.php
@@ -109,7 +109,7 @@ class ModifyCloudCommandTest extends CommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/ModifyProfileCommandTest.php
+++ b/Tests/Command/ModifyProfileCommandTest.php
@@ -124,7 +124,7 @@ class ModifyProfileCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/ProfileInfoCommandTest.php
+++ b/Tests/Command/ProfileInfoCommandTest.php
@@ -44,7 +44,7 @@ class ProfileInfoCommandTest extends CloudCommandTest
             ->expects($this->once())
             ->method('getProfile')
             ->will($this->returnValue($profile));
-        $this->runCommand('panda:profile:info', array('profile-id', $profileId));
+        $this->runCommand('panda:profile:info', array('profile-id' => $profileId));
         $this->validateTableRows(array(
             array('id', $profileId),
             array('title', 'MP4 (H.264)'),
@@ -60,7 +60,7 @@ class ProfileInfoCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/RetryEncodingCommandTest.php
+++ b/Tests/Command/RetryEncodingCommandTest.php
@@ -41,7 +41,7 @@ class RetryEncodingCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/UploadVideoCommandTest.php
+++ b/Tests/Command/UploadVideoCommandTest.php
@@ -88,7 +88,7 @@ class UploadVideoCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/VideoInfoCommandTest.php
+++ b/Tests/Command/VideoInfoCommandTest.php
@@ -83,7 +83,7 @@ class VideoInfoCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {

--- a/Tests/Command/VideoMetadataCommandTest.php
+++ b/Tests/Command/VideoMetadataCommandTest.php
@@ -49,7 +49,7 @@ class VideoMetadataCommandTest extends CloudCommandTest
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments
      */
     public function testCommandWithoutArguments()
     {


### PR DESCRIPTION
This makes test pass again given the improvements to the message of the
exception that is thrown since symfony/symfony#15533 when a required
argument is missing.