### PR TITLE
improve the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,15 @@ matrix:
     - php: 5.4
     - php: 5.5
     - php: 5.6
-      env: SYMFONY_VERSION="2.3.x"
-    - php: 5.6
       env: SYMFONY_VERSION="2.7.x"
     - php: 5.6
-      env: SYMFONY_VERSION="2.8.x@dev"
+      env: SYMFONY_VERSION="2.8.x"
     - php: 7.0
-    - php: hhvm
-  allow_failures:
+      env: xdebug=yes
     - php: hhvm
 
 before_install:
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" && "$xdebug" != "yes" ]]; then phpenv config-rm xdebug.ini; fi
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --dev --no-update; fi
 
 install:
@@ -37,9 +35,8 @@ install:
   - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
 
 script:
-  - phpunit --coverage-clover=coverage.clover
+  - if [[ "$xdebug" = "yes" ]]; then phpunit --coverage-clover=coverage.clover; else phpunit; fi
 
 after_script:
-  # PHP 7.0 and HHVM 3.5 are not able to generate code coverage
-  # Avoid notifying that generating it failed to let other jobs upload it rather than  cancelling the Scrutinizer job
-  - if [[ "$TRAVIS_PHP_VERSION" != "7.0" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [[ "$xdebug" = "yes" ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [[ "$xdebug" = "yes" ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi


### PR DESCRIPTION
* run coverage reports on PHP 7 only
* do not allow HHVM jobs to fail
* run tests against stable Symfony releases
* drop jobs for Symfony versions that have reached their EOM