### PR TITLE
Update the bundle to use the HTTPlug integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,8 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
+    - php: 5.6
       env: COMPOSER_OPTIONS="--prefer-lowest --prefer-stable"
-    - php: 5.4
-    - php: 5.5
     - php: 5.6
     # Test against LTS versions
     - php: 7.0

--- a/Cloud/CloudFactory.php
+++ b/Cloud/CloudFactory.php
@@ -11,10 +11,9 @@
 
 namespace Xabbuh\PandaBundle\Cloud;
 
-use Guzzle\Http\Client;
 use Xabbuh\PandaClient\Api\AccountManagerInterface;
 use Xabbuh\PandaClient\Api\Cloud;
-use Xabbuh\PandaClient\Api\HttpClient;
+use Xabbuh\PandaClient\Api\HttplugClient;
 use Xabbuh\PandaClient\Transformer\TransformerRegistryInterface;
 
 /**
@@ -51,12 +50,9 @@ class CloudFactory implements CloudFactoryInterface
     {
         $account = $this->accountManager->getAccount($accountKey);
 
-        $guzzleClient = new Client('https://'.$account->getApiHost().'/v2');
-
-        $httpClient = new HttpClient();
+        $httpClient = new HttplugClient();
         $httpClient->setCloudId($cloudId);
         $httpClient->setAccount($account);
-        $httpClient->setGuzzleClient($guzzleClient);
 
         $cloud = new Cloud();
         $cloud->setHttpClient($httpClient);

--- a/Cloud/CloudFactory.php
+++ b/Cloud/CloudFactory.php
@@ -11,6 +11,8 @@
 
 namespace Xabbuh\PandaBundle\Cloud;
 
+@trigger_error('The Xabbuh\PandaBundle\Cloud\CloudFactory class is deprecated since version 1.3 and will be removed in 2.0', E_USER_DEPRECATED);
+
 use Xabbuh\PandaClient\Api\AccountManagerInterface;
 use Xabbuh\PandaClient\Api\Cloud;
 use Xabbuh\PandaClient\Api\HttplugClient;
@@ -20,6 +22,8 @@ use Xabbuh\PandaClient\Transformer\TransformerRegistryInterface;
  * Factory to create Cloud instances.
  *
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * @deprecated since version 1.3, to be removed in 2.0
  */
 class CloudFactory implements CloudFactoryInterface
 {

--- a/Cloud/CloudFactoryInterface.php
+++ b/Cloud/CloudFactoryInterface.php
@@ -11,12 +11,16 @@
 
 namespace Xabbuh\PandaBundle\Cloud;
 
+@trigger_error('The Xabbuh\PandaBundle\Cloud\CloudFactoryInterface interface is deprecated since version 1.3 and will be removed in 2.0', E_USER_DEPRECATED);
+
 use Xabbuh\PandaClient\Api\Cloud;
 
 /**
  * Interface definition for cloud factory implementations.
  *
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * @deprecated since version 1.3, to be removed in 2.0
  */
 interface CloudFactoryInterface
 {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -68,6 +68,15 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('httplug')
+                    ->info('Allow configuring the HTTPlug objects being used, instead of creating new ones using the discovery system.')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('client')->defaultNull()->end()
+                        ->scalarNode('request_factory')->defaultNull()->end()
+                        ->scalarNode('stream_factory')->defaultNull()->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/XabbuhPandaExtension.php
+++ b/DependencyInjection/XabbuhPandaExtension.php
@@ -13,7 +13,9 @@ namespace Xabbuh\PandaBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -92,15 +94,29 @@ class XabbuhPandaExtension extends Extension
         $cloudManagerDefinition = $container->getDefinition('xabbuh_panda.cloud_manager');
 
         foreach ($clouds as $name => $cloudConfig) {
+            $accountDefinition = new Definition('Xabbuh\PandaClient\Api\Account');
+            $accountDefinition->setFactory(array(new Reference('xabbuh_panda.account_manager'), 'getAccount'));
+
+            $accountDefinition->addArgument(isset($cloudConfig['account']) ? $cloudConfig['account'] : null);
+
+            if (class_exists('Symfony\Component\DependencyInjection\ChildDefinition')) {
+                $httpClientDefinition = new ChildDefinition('xabbuh_panda.http_client');
+            } else {
+                $httpClientDefinition = new DefinitionDecorator('xabbuh_panda.http_client');
+            }
+
+            $httpClientDefinition->setPublic(false);
+            $httpClientDefinition->addMethodCall('setAccount', array($accountDefinition));
+            $httpClientDefinition->addMethodCall('setCloudId', array($cloudConfig['id']));
+
+            $httpClientId = 'xabbuh_panda.http_client.'.strtr($name, ' -', '_');
+
+            $container->setDefinition($httpClientId, $httpClientDefinition);
+
             // register each cloud as a service
-            $cloudDefinition = new Definition(
-                'Xabbuh\PandaClient\Api\Cloud',
-                array(
-                    $cloudConfig['id'],
-                    isset($cloudConfig['account']) ? $cloudConfig['account'] : null,
-                )
-            );
-            $cloudDefinition->setFactory(array(new Reference('xabbuh_panda.cloud_factory'), 'get'));
+            $cloudDefinition = new Definition('Xabbuh\PandaClient\Api\Cloud');
+            $cloudDefinition->addMethodCall('setHttpClient', array(new Reference($httpClientId)));
+            $cloudDefinition->addMethodCall('setTransformers', array(new Reference('xabbuh_panda.transformer')));
 
             $id = 'xabbuh_panda.'.strtr($name, ' -', '_').'_cloud';
             $container->setDefinition($id, $cloudDefinition);

--- a/DependencyInjection/XabbuhPandaExtension.php
+++ b/DependencyInjection/XabbuhPandaExtension.php
@@ -62,6 +62,14 @@ class XabbuhPandaExtension extends Extension
 
         $this->loadAccounts($config['accounts'], $container);
         $this->loadClouds($config['clouds'], $container);
+
+        $baseHttpClientDefinition = $container->getDefinition('xabbuh_panda.http_client');
+
+        foreach (array('client' => 0, 'request_factory' => 1, 'stream_factory' => 2) as $key => $argumentIndex) {
+            if (null !== $config['httplug'][$key]) {
+                $baseHttpClientDefinition->replaceArgument($argumentIndex, new Reference($config['httplug'][$key]));
+            }
+        }
     }
 
     private function loadAccounts(array $accounts, ContainerBuilder $container)

--- a/Resources/config/cloud_manager.xml
+++ b/Resources/config/cloud_manager.xml
@@ -13,5 +13,11 @@
                 <argument>%xabbuh_panda.cloud.default%</argument>
             </call>
         </service>
+
+        <service id="xabbuh_panda.http_client" class="Xabbuh\PandaClient\Api\HttplugClient" abstract="true">
+            <argument>null</argument>
+            <argument>null</argument>
+            <argument>null</argument>
+        </service>
     </services>
 </container>

--- a/Tests/Cloud/CloudFactoryTest.php
+++ b/Tests/Cloud/CloudFactoryTest.php
@@ -67,18 +67,6 @@ class CloudFactoryTest extends TestCase
         $this->assertEquals($this->account, $httpClient->getAccount());
     }
 
-    public function testGuzzleClientFromGet()
-    {
-        $cloud = $this->cloudFactory->get(md5(uniqid()), 'foo');
-        $guzzleClient = $cloud->getHttpClient()->getGuzzleClient();
-
-        $this->assertInstanceOf('\Guzzle\Http\Client', $guzzleClient);
-        $this->assertEquals(
-            'https://example.com/v2',
-            $guzzleClient->getBaseUrl()
-        );
-    }
-
     public function testTransformerRegistryFromGet()
     {
         $cloud = $this->cloudFactory->get(md5(uniqid()), 'foo');

--- a/Tests/Cloud/CloudFactoryTest.php
+++ b/Tests/Cloud/CloudFactoryTest.php
@@ -11,12 +11,15 @@
 
 namespace Xabbuh\PandaBundle\Tests\Cloud;
 
+use Http\Discovery\HttpClientDiscovery;
 use PHPUnit\Framework\TestCase;
 use Xabbuh\PandaBundle\Cloud\CloudFactory;
 use Xabbuh\PandaClient\Api\Account;
 
 /**
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * @group legacy
  */
 class CloudFactoryTest extends TestCase
 {
@@ -48,6 +51,8 @@ class CloudFactoryTest extends TestCase
             $this->accountManager,
             $this->transformerRegistry
         );
+
+        HttpClientDiscovery::prependStrategy('Http\Discovery\Strategy\MockClientStrategy');
     }
 
     public function testGet()

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "psr-4": { "Xabbuh\\PandaBundle\\": "" }
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": "^5.6 || ^7.0",
         "symfony/config": "^2.8||^3.0",
         "symfony/console": "^2.8||^3.0",
         "symfony/dependency-injection": "^2.8||^3.0",
@@ -24,10 +24,12 @@
         "symfony/http-kernel": "^2.8||^3.0",
         "symfony/options-resolver": "^2.8||^3.0",
         "symfony/routing": "^2.8||^3.0",
-        "xabbuh/panda-client": "^1.2.3"
+        "xabbuh/panda-client": "^1.3"
     },
     "require-dev": {
+        "guzzlehttp/psr7": "^1.4",
         "matthiasnoback/symfony-dependency-injection-test": "~0.7",
+        "php-http/mock-client": "^1.0",
         "symfony/browser-kit": "^2.8||^3.0",
         "symfony/dom-crawler": "^2.8||^3.0",
         "symfony/finder": "^2.8||^3.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.4",
-        "matthiasnoback/symfony-dependency-injection-test": "~0.7",
+        "matthiasnoback/symfony-dependency-injection-test": "~1.0",
+        "phpunit/phpunit": "^5.7.19",
         "php-http/mock-client": "^1.0",
         "symfony/browser-kit": "^2.8||^3.0",
         "symfony/dom-crawler": "^2.8||^3.0",


### PR DESCRIPTION
Depends on https://github.com/xabbuh/panda-client/pull/16

The work needed to support it is actually quite small. It is the first commit of this PR (and currently, it contains extra changes to use my fork until the PR is merged, but I will amend it once the PR is merged in panda-client).

The third commit is about making it possible to provide your own HTTPlug client (and also the message factory and the stream factory, even though it is less needed for them as the factory themselves are not configurable so the option is useful only to force a different factory than the one selected by the discovery layer when you have multiple ones installed).
The second commit is the preparatory work for the third commit: moving the instantiation of the HttplugClient to the DIC rather than using the CloudFactory, to be able to inject extra services easily. I deprecated the CloudFactory in the process (it is not tagged as `@internal`, but it clearly looks like an internal API as it is meant to be a factory service, and I got rid of it).

Note that configuring the HTTPlug client applies to all clouds. I have not found it useful to allow separate configuration per cloud (but it would be possible to implement it in a BC way in the future).