### PR TITLE
Mark the cloud_factory service as deprecated

### DIFF
--- a/Resources/config/cloud_factory.xml
+++ b/Resources/config/cloud_factory.xml
@@ -7,6 +7,7 @@
     </parameters>
     <services>
         <service id="xabbuh_panda.cloud_factory" class="%xabbuh_panda.cloud.factory.class%">
+            <deprecated />
             <argument type="service" id="xabbuh_panda.account_manager"/>
             <argument type="service" id="xabbuh_panda.transformer"/>
         </service>

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^5.6 || ^7.0",
         "symfony/config": "^2.8||^3.0",
         "symfony/console": "^2.8||^3.0",
-        "symfony/dependency-injection": "^2.8||^3.0",
+        "symfony/dependency-injection": "^2.8.9||^3.1.3",
         "symfony/event-dispatcher": "^2.8||^3.0",
         "symfony/form": "^2.8||^3.0",
         "symfony/http-foundation": "^2.8||^3.0",


### PR DESCRIPTION
This service uses a deprecated class, so a deprecation warning would already appear when using it (saying the class is deprecated). However, this is not ideal.
In case you use autowiring and one of the argument cannot be autowired with the new way, the Symfony 3.3 BC layer will load available types to attempt using the old way. But doing this will load the CloudFactory class (to create a ReflectionClass) and so trigger a deprecation here (while the service is never used). Such case even happen when you have an optional argument which does not get autowired at all (setting it to `null`), which is not a case where Symfony expects you to change your code (and so you get only the confusing deprecation for the CloudFactory class).
Thus, if you are affected by this autowiring case making the deprecation appear all the time, you would miss cases where you were actually using the deprecated class yourselves.

The AutowirePass ignores deprecated services when loading the available types for the BC layer. So marking the service as deprecated avoids the pitfall (the CloudFactory deprecation will appear only if they actually use the service, not just because they use autowiring)