### PR TITLE
Add autowiring support

### DIFF
--- a/DependencyInjection/XabbuhPandaExtension.php
+++ b/DependencyInjection/XabbuhPandaExtension.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Xabbuh\PandaClient\Api\CloudInterface;
 
 /**
  * XabbuhPandaExtension.
@@ -62,6 +63,14 @@ class XabbuhPandaExtension extends Extension
 
         $this->loadAccounts($config['accounts'], $container);
         $this->loadClouds($config['clouds'], $container);
+
+        if (!empty($config['clouds'])) {
+            $autowiredCloud = new Definition(CloudInterface::class);
+            $autowiredCloud->setPublic(false);
+            $autowiredCloud->setFactory(array(new Reference('xabbuh_panda.cloud_manager'), 'getCloud'));
+
+            $container->setDefinition(CloudInterface::class, $autowiredCloud);
+        }
 
         $baseHttpClientDefinition = $container->getDefinition('xabbuh_panda.http_client');
 

--- a/Resources/config/cloud_manager.xml
+++ b/Resources/config/cloud_manager.xml
@@ -13,6 +13,7 @@
                 <argument>%xabbuh_panda.cloud.default%</argument>
             </call>
         </service>
+        <service id="Xabbuh\PandaClient\Api\CloudManagerInterface" alias="xabbuh_panda.cloud_manager" public="false" />
 
         <service id="xabbuh_panda.http_client" class="Xabbuh\PandaClient\Api\HttplugClient" abstract="true">
             <argument>null</argument>


### PR DESCRIPTION
The CloudManagerInterface is autowired. And the CloudInterface is autowired using the default cloud when at least one cloud is available.