### PR TITLE
Improve the way services are referenced internally

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -77,7 +77,20 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('stream_factory')->defaultNull()->end()
                     ->end()
                 ->end()
-            ->end();
+            ->end()
+            ->validate()
+                ->ifTrue(function ($v) {
+                    return !empty($v['clouds']) && !isset($v['clouds'][$v['default_cloud']]);
+                })
+                ->thenInvalid('The configured default cloud is not one of the configured clouds.')
+            ->end()
+            ->validate()
+                ->ifTrue(function ($v) {
+                    return !empty($v['accounts']) && !isset($v['accounts'][$v['default_account']]);
+                })
+                ->thenInvalid('The configured default account is not one of the configured accounts.')
+            ->end()
+        ;
 
         return $treeBuilder;
     }

--- a/Tests/DependencyInjection/XabbuhPandaExtensionTest.php
+++ b/Tests/DependencyInjection/XabbuhPandaExtensionTest.php
@@ -87,6 +87,7 @@ class XabbuhPandaExtensionTest extends AbstractExtensionTestCase
     {
         $this->load(array(
             'default_account' => 'default',
+            'default_cloud' => 'with_account',
             'clouds' => array(
                 'with_account' => array(
                     'id' => 'foo',
@@ -96,6 +97,10 @@ class XabbuhPandaExtensionTest extends AbstractExtensionTestCase
                     'id' => 'foobar',
                 ),
             ),
+            'accounts' => array(
+                'default' => array('access_key' => 'fake', 'secret_key' => 'fake_secret'),
+                'bar' => array('access_key' => 'fake2', 'secret_key' => 'fake_secret2'),
+            )
         ));
 
         $this->ensureThatDefinitionsAreRegistered(array(
@@ -115,13 +120,9 @@ class XabbuhPandaExtensionTest extends AbstractExtensionTestCase
             array(new Reference('xabbuh_panda.http_client.without_account'))
         );
 
-        $accountDef = new Definition('Xabbuh\PandaClient\Api\Account', array('bar'));
-        $accountDef->setFactory(array(new Reference('xabbuh_panda.account_manager'), 'getAccount'));
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('xabbuh_panda.http_client.with_account', 'setAccount', array($accountDef));
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('xabbuh_panda.http_client.with_account', 'setAccount', array(new Reference('xabbuh_panda.bar_account')));
 
-        $withoutAccountDef = new Definition('Xabbuh\PandaClient\Api\Account', array(null));
-        $withoutAccountDef->setFactory(array(new Reference('xabbuh_panda.account_manager'), 'getAccount'));
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('xabbuh_panda.http_client.without_account', 'setAccount', array($withoutAccountDef));
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('xabbuh_panda.http_client.without_account', 'setAccount', array(new Reference('xabbuh_panda.default_account')));
     }
 
     protected function getContainerExtensions()


### PR DESCRIPTION
Usage of the managers is avoided internally when possible, using a direct reference to the appropriate service instead. This improves the case where multiple accounts or clouds are defined, as each manager eagerly instantiates all objects it manages (no lazy-loading).

This PR is currently based on top of #30 as the new code added in it is patched here too.