### PR TITLE
Mark the controller service as public

### DIFF
--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -6,7 +6,7 @@
         <parameter key="xabbuh_panda.controller.class">Xabbuh\PandaBundle\Controller\Controller</parameter>
     </parameters>
     <services>
-        <service id="xabbuh_panda.controller" class="%xabbuh_panda.controller.class%">
+        <service id="xabbuh_panda.controller" class="%xabbuh_panda.controller.class%" public="true">
             <argument type="service" id="xabbuh_panda.cloud_manager" />
             <argument type="service" id="event_dispatcher" />
         </service>


### PR DESCRIPTION
Symfony 4.0 will make services private by default. Even though the status of other services of the bundle is still in discussion, the controller is required to stay public, as it is referenced by the route.