### PR TITLE
favor symfony/lts over symfony/symfony

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   global:
     - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
     - COMPOSER_OPTIONS="--prefer-stable"
-    - SYMFONY_VERSION=""
 
 matrix:
   fast_finish: true
@@ -21,9 +20,9 @@ matrix:
     - php: 5.6
     # Test against LTS versions
     - php: 5.6
-      env: SYMFONY_VERSION="2.8.x"
+      env: SYMFONY_LTS="^2"
     - php: 7.0
-      env: SYMFONY_VERSION="3.4.x"
+      env: SYMFONY_LTS="^3"
     # Test against dev versions
     - php: 7.1
       env: xdebug=yes COMPOSER_OPTIONS=""
@@ -31,7 +30,7 @@ matrix:
 before_install:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo memory_limit = -1 >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
   - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" && "$xdebug" != "yes" ]]; then phpenv config-rm xdebug.ini; fi
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --dev --no-update; fi
+  - if [ "$SYMFONY_LTS" != "" ]; then composer require symfony/lts:${SYMFONY_LTS} --dev --no-update; fi
 
 install:
   - composer update $COMPOSER_OPTIONS


### PR DESCRIPTION
This allows to not mistakenly pull in more package during tests that
would not be installed in a real application that does not depend on
the symfony/symfony package.