### PR TITLE
add build job for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     - php: 5.6
       env: COMPOSER_OPTIONS="--prefer-lowest --prefer-stable"
     - php: 5.6
+    - php: 7.1
     # Test against LTS versions
     - php: 5.6
       env: SYMFONY_LTS="^2"


### PR DESCRIPTION
This also has the side effect that we now have an actual build on Travis
CI that runs with stable Symfony 4 based dependencies.