### PR TITLE
Define commands as a service for recent Symfony versions

### DIFF
--- a/Command/CancelEncodingCommand.php
+++ b/Command/CancelEncodingCommand.php
@@ -23,12 +23,13 @@ use Xabbuh\PandaClient\Model\Encoding;
  */
 class CancelEncodingCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:encoding:cancel';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:encoding:cancel');
         $this->setDescription('Cancel an encoding');
         $this->addArgument(
             'encoding-id',

--- a/Command/ChangeUrlCommand.php
+++ b/Command/ChangeUrlCommand.php
@@ -23,12 +23,13 @@ use Xabbuh\PandaClient\Model\Notifications;
  */
 class ChangeUrlCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:notifications:change-url';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:notifications:change-url');
         $this->setDescription('Change the endpoint for notification requests');
         $this->addArgument('url', InputArgument::REQUIRED, 'The new url', null);
 

--- a/Command/CloudCommand.php
+++ b/Command/CloudCommand.php
@@ -12,8 +12,6 @@
 namespace Xabbuh\PandaBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Helper\TableHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -34,6 +32,7 @@ abstract class CloudCommand extends ContainerAwareCommand
      */
     protected function configure()
     {
+        $this->setName(static::$defaultName); // BC with Symfony Console 3.3 and older not handling the property automatically
         $this->addOption(
             'cloud',
             '-c',
@@ -55,7 +54,7 @@ abstract class CloudCommand extends ContainerAwareCommand
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input
      *
-     * @return \Xabbuh\PandaClient\Api\Cloud
+     * @return \Xabbuh\PandaClient\Api\CloudInterface
      */
     protected function getCloud(InputInterface $input)
     {

--- a/Command/CloudInfoCommand.php
+++ b/Command/CloudInfoCommand.php
@@ -22,12 +22,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class CloudInfoCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:cloud:info';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:cloud:info');
         $this->setDescription('Display details of a cloud');
 
         parent::configure();

--- a/Command/CreateEncodingCommand.php
+++ b/Command/CreateEncodingCommand.php
@@ -24,12 +24,13 @@ use Xabbuh\PandaClient\Model\Video;
  */
 class CreateEncodingCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:encoding:create';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:encoding:create');
         $this->setDescription('Create an encoding');
         $this->addArgument(
             'video-id',

--- a/Command/CreateProfileCommand.php
+++ b/Command/CreateProfileCommand.php
@@ -22,12 +22,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class CreateProfileCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:profile:create';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:profile:create');
         $this->setDescription('Create a profile based on a given preset');
         $this->addArgument(
         'preset',

--- a/Command/DeleteEncodingCommand.php
+++ b/Command/DeleteEncodingCommand.php
@@ -23,12 +23,13 @@ use Xabbuh\PandaClient\Model\Encoding;
  */
 class DeleteEncodingCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:encoding:delete';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:encoding:delete');
         $this->setDescription('Delete an encoding');
         $this->addArgument(
             'encoding-id',

--- a/Command/DeleteProfileCommand.php
+++ b/Command/DeleteProfileCommand.php
@@ -23,12 +23,13 @@ use Xabbuh\PandaClient\Model\Profile;
  */
 class DeleteProfileCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:profile:delete';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:profile:delete');
         $this->setDescription('Delete a profile');
         $this->addArgument(
             'profile-id',

--- a/Command/DeleteVideoCommand.php
+++ b/Command/DeleteVideoCommand.php
@@ -23,12 +23,12 @@ use Xabbuh\PandaClient\Model\Video;
  */
 class DeleteVideoCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:video:delete';
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:video:delete');
         $this->setDescription('Delete a video');
         $this->addArgument(
             'video-id',

--- a/Command/DisableEventCommand.php
+++ b/Command/DisableEventCommand.php
@@ -24,12 +24,13 @@ use Xabbuh\PandaClient\Model\Notifications;
  */
 class DisableEventCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:notifications:disable';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:notifications:disable');
         $this->setDescription('Disable a notification event');
         $this->addArgument(
             'event',

--- a/Command/EnableEventCommand.php
+++ b/Command/EnableEventCommand.php
@@ -24,12 +24,12 @@ use Xabbuh\PandaClient\Model\Notifications;
  */
 class EnableEventCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:notifications:enable';
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:notifications:enable');
         $this->setDescription('Enable a notification event');
         $this->addArgument(
             'event',

--- a/Command/EncodingInfoCommand.php
+++ b/Command/EncodingInfoCommand.php
@@ -23,12 +23,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class EncodingInfoCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:encoding:info';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:encoding:info');
         $this->setDescription('Fetch information for an encoding');
         $this->addArgument(
             'encoding-id',

--- a/Command/ListEncodingsCommand.php
+++ b/Command/ListEncodingsCommand.php
@@ -23,12 +23,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ListEncodingsCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:encoding:list';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:encoding:list');
         $this->setDescription('Display a (optionally filtered) list of encodings');
         $this->addOption(
             'status',

--- a/Command/ListProfilesCommand.php
+++ b/Command/ListProfilesCommand.php
@@ -22,12 +22,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ListProfilesCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:profile:list';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:profile:list');
         $this->setDescription('List all profiles of a cloud');
 
         parent::configure();

--- a/Command/ListVideosCommand.php
+++ b/Command/ListVideosCommand.php
@@ -23,12 +23,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ListVideosCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:video:list';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:video:list');
         $this->setDescription('List all videos of a cloud');
         $this->addOption(
             'page',

--- a/Command/ModifyCloudCommand.php
+++ b/Command/ModifyCloudCommand.php
@@ -24,12 +24,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ModifyCloudCommand extends ContainerAwareCommand
 {
+    protected static $defaultName = 'panda:cloud:modify';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:cloud:modify');
+        $this->setName(static::$defaultName); // BC with Symfony Console 3.3 and older not handling the property automatically
         $this->setDescription('Modify a cloud');
         $this->addOption(
             'account',

--- a/Command/ModifyProfileCommand.php
+++ b/Command/ModifyProfileCommand.php
@@ -23,12 +23,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ModifyProfileCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:profile:modify';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:profile:modify');
         $this->setDescription('Modify a profile');
         $this->addArgument(
             'profile-id',

--- a/Command/ProfileInfoCommand.php
+++ b/Command/ProfileInfoCommand.php
@@ -23,12 +23,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ProfileInfoCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:profile:info';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:profile:info');
         $this->setDescription('Fetch information for a profile');
         $this->addArgument(
             'profile-id',

--- a/Command/RetryEncodingCommand.php
+++ b/Command/RetryEncodingCommand.php
@@ -23,12 +23,13 @@ use Xabbuh\PandaClient\Model\Encoding;
  */
 class RetryEncodingCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:encoding:retry';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:encoding:retry');
         $this->setDescription('Restart an encoding');
         $this->addArgument(
             'encoding-id',

--- a/Command/ShowNotificationsCommand.php
+++ b/Command/ShowNotificationsCommand.php
@@ -22,12 +22,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ShowNotificationsCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:notifications:show';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:notifications:show');
         $this->setDescription('Show the current notification configuration');
 
         parent::configure();

--- a/Command/UploadVideoCommand.php
+++ b/Command/UploadVideoCommand.php
@@ -23,12 +23,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class UploadVideoCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:video:upload';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:video:upload');
         $this->setDescription('Upload a video');
         $this->addOption(
             'profile',

--- a/Command/VideoInfoCommand.php
+++ b/Command/VideoInfoCommand.php
@@ -23,12 +23,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class VideoInfoCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:video:info';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:video:info');
         $this->setDescription('Fetch information for a video');
         $this->addArgument(
             'video-id',

--- a/Command/VideoMetadataCommand.php
+++ b/Command/VideoMetadataCommand.php
@@ -23,12 +23,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class VideoMetadataCommand extends CloudCommand
 {
+    protected static $defaultName = 'panda:video:metadata';
+
     /**
      * {@inheritDoc}
      */
     protected function configure()
     {
-        $this->setName('panda:video:metadata');
         $this->setDescription('Fetch metadata for a video');
         $this->addArgument(
             'video-id',

--- a/DependencyInjection/XabbuhPandaExtension.php
+++ b/DependencyInjection/XabbuhPandaExtension.php
@@ -57,6 +57,7 @@ class XabbuhPandaExtension extends Extension
         $loader->load('account_manager.xml');
         $loader->load('cloud_manager.xml');
         $loader->load('cloud_factory.xml');
+        $loader->load('commands.xml');
         $loader->load('controller.xml');
         $loader->load('transformers.xml');
         $loader->load('video_uploader_extension.xml');

--- a/Resources/config/commands.xml
+++ b/Resources/config/commands.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="xabbuh_panda.command.cancel_encoding_command" class="Xabbuh\PandaBundle\Command\CancelEncodingCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.change_url_command" class="Xabbuh\PandaBundle\Command\ChangeUrlCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.cloud_info_command" class="Xabbuh\PandaBundle\Command\CloudInfoCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.create_encoding_command" class="Xabbuh\PandaBundle\Command\CreateEncodingCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.create_profile_command" class="Xabbuh\PandaBundle\Command\CreateProfileCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.delete_encoding_command" class="Xabbuh\PandaBundle\Command\DeleteEncodingCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.delete_profile_command" class="Xabbuh\PandaBundle\Command\DeleteProfileCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.delete_video_command" class="Xabbuh\PandaBundle\Command\DeleteVideoCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.disable_event_command" class="Xabbuh\PandaBundle\Command\DisableEventCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.enable_event_command" class="Xabbuh\PandaBundle\Command\EnableEventCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.encoding_info_command" class="Xabbuh\PandaBundle\Command\EncodingInfoCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.list_encodings_command" class="Xabbuh\PandaBundle\Command\ListEncodingsCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.list_profiles_command" class="Xabbuh\PandaBundle\Command\ListProfilesCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.list_videos_command" class="Xabbuh\PandaBundle\Command\ListVideosCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.modify_cloud_command" class="Xabbuh\PandaBundle\Command\ModifyCloudCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.modify_profile_command" class="Xabbuh\PandaBundle\Command\ModifyProfileCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.profile_info_command" class="Xabbuh\PandaBundle\Command\ProfileInfoCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.retry_encoding_command" class="Xabbuh\PandaBundle\Command\RetryEncodingCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.show_notifications_command" class="Xabbuh\PandaBundle\Command\ShowNotificationsCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.upload_video_command" class="Xabbuh\PandaBundle\Command\UploadVideoCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.video_info_command" class="Xabbuh\PandaBundle\Command\VideoInfoCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="xabbuh_panda.command.video_metadata_command" class="Xabbuh\PandaBundle\Command\VideoMetadataCommand">
+            <tag name="console.command" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
The automatic discovery of commands is deprecated as of 3.4 and gone in 4.0.

refs #29

To keep things simple, I haven't refactored commands to use proper DI for now. They are still container aware commands. Such refactoring is left for a future PR (and should probably be done only after dropping support for Symfony < 3.4, to avoid loading the whole object graph on older versions of Symfony not supporting lazy-loading).

Moving the name to a `public static $defaultName` allows lazy-loading of commands in Symfony 3.4+ (as the compiler pass can determine the name at compile time without having to instantiate the command and changes the way it registers the command).
To avoid duplicating the name, I removed it from `configure` in all classes, and I added code setting the name from this default name in the common parent class (symfony/console 3.4 already has this logic in the base Command class, but this allows supporting 3.3 and older, with only 3 LOC for the BC layer).

