### PR TITLE
do not require PHPUnit packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.4",
-        "matthiasnoback/symfony-dependency-injection-test": "~1.0",
-        "phpunit/phpunit": "^5.7.19",
+        "matthiasnoback/symfony-dependency-injection-test": "^2.0||^3.0||^4.0",
         "php-http/mock-client": "^1.0",
         "symfony/browser-kit": "^3.4||^4.2",
         "symfony/dom-crawler": "^3.4||^4.2",


### PR DESCRIPTION
The Symfony PHPUnit bridge is able to install a compatible PHPUnit
version and all required dependencies itself.